### PR TITLE
Change "i.e." to "e.g." in placeholders

### DIFF
--- a/client/src/data/form-publish.json
+++ b/client/src/data/form-publish.json
@@ -6,14 +6,14 @@
       "fields": {
         "name": {
           "label": "Title",
-          "placeholder": "i.e. Almond sales data",
+          "placeholder": "e.g. Almond sales data",
           "type": "text",
           "required": true,
           "help": "Enter a concise title. You will be able to enter a more thorough description in the next step."
         },
         "files": {
           "label": "Files",
-          "placeholder": "i.e. https://file.com/file.json",
+          "placeholder": "e.g. https://file.com/file.json",
           "type": "text",
           "required": true,
           "help": "Provide one or multiple urls to your data set files."
@@ -27,7 +27,7 @@
         "description": {
           "label": "Description",
           "help": "Add a thorough description with as much detail as possible.",
-          "placeholder": "i.e. Almond sales data ",
+          "placeholder": "e.g. Almond sales data ",
           "type": "textarea",
           "required": true,
           "rows": 5
@@ -85,13 +85,13 @@
       "fields": {
         "author": {
           "label": "Author",
-          "placeholder": "i.e. Jelly McJellyfish",
+          "placeholder": "e.g. Jelly McJellyfish",
           "type": "text",
           "required": true
         },
         "copyrightHolder": {
           "label": "Copyright Holder",
-          "placeholder": "i.e. Marine Institute of Jellyfish",
+          "placeholder": "e.g. Marine Institute of Jellyfish",
           "type": "text",
           "required": true
         },

--- a/client/src/data/form-styleguide.json
+++ b/client/src/data/form-styleguide.json
@@ -4,20 +4,20 @@
   "fields": {
     "name": {
       "label": "Your name",
-      "placeholder": "i.e. Jelly McJellyfish",
+      "placeholder": "e.g. Jelly McJellyfish",
       "type": "text",
       "required": true,
       "help": "Help me"
     },
     "email": {
       "label": "Your email",
-      "placeholder": "i.e. jelly@mcjellyfish.com",
+      "placeholder": "e.g. jelly@mcjellyfish.com",
       "type": "email",
       "required": true
     },
     "message": {
       "label": "Your message",
-      "placeholder": "i.e. jelly@mcjellyfish.com",
+      "placeholder": "e.g. jelly@mcjellyfish.com",
       "type": "textarea",
       "required": true
     },
@@ -41,7 +41,7 @@
     },
     "date": {
       "label": "Date",
-      "placeholder": "i.e. 2019-08-12",
+      "placeholder": "e.g. 2019-08-12",
       "type": "date",
       "required": true
     }

--- a/client/src/routes/Home.tsx
+++ b/client/src/routes/Home.tsx
@@ -31,7 +31,7 @@ class Home extends Component<HomeProps, HomeState> {
                         type="search"
                         name="search"
                         label="Search for data sets"
-                        placeholder="i.e. almond sales data"
+                        placeholder="e.g. almond sales data"
                         value={this.state.search}
                         onChange={this.inputChange}
                         group={


### PR DESCRIPTION
"i.e." means "that is"

"e.g." means "for example"

Therefore, the examples given in the form field placeholders should say "e.g. something", not "i.e. something"
