### PR TITLE
Change sample data set/search to one w/ results

### DIFF
--- a/client/src/data/form-publish.json
+++ b/client/src/data/form-publish.json
@@ -6,7 +6,7 @@
       "fields": {
         "name": {
           "label": "Title",
-          "placeholder": "e.g. Almond sales data",
+          "placeholder": "e.g. Shapes of Desert Plants",
           "type": "text",
           "required": true,
           "help": "Enter a concise title. You will be able to enter a more thorough description in the next step."
@@ -27,7 +27,7 @@
         "description": {
           "label": "Description",
           "help": "Add a thorough description with as much detail as possible.",
-          "placeholder": "e.g. Almond sales data ",
+          "placeholder": "e.g. Shapes of 23 common desert plants.",
           "type": "textarea",
           "required": true,
           "rows": 5

--- a/client/src/routes/Home.tsx
+++ b/client/src/routes/Home.tsx
@@ -31,7 +31,7 @@ class Home extends Component<HomeProps, HomeState> {
                         type="search"
                         name="search"
                         label="Search for data sets"
-                        placeholder="e.g. almond sales data"
+                        placeholder="e.g. shapes of plants"
                         value={this.state.search}
                         onChange={this.inputChange}
                         group={


### PR DESCRIPTION
The example search on the Commons Marketplace home page was "e.g. almond sales data" but there were no search results for that. This changes the example search to one with 25 search results, namely "shapes of plants".

It also changes the placeholder title and description in the publish forms, to something similar.
