### PR TITLE
search updates for Aquarius 0.2.2

### DIFF
--- a/client/src/components/molecules/Pagination.tsx
+++ b/client/src/components/molecules/Pagination.tsx
@@ -47,7 +47,7 @@ export default class Pagination extends PureComponent<{
 }> {
     public render() {
         const { currentPage, totalPages, prevPage, setPage } = this.props
-        const isFirst = currentPage === 0
+        const isFirst = currentPage === 1
         const isLast = currentPage === totalPages
 
         return totalPages > 1 ? (

--- a/client/src/routes/Search.tsx
+++ b/client/src/routes/Search.tsx
@@ -28,7 +28,7 @@ export default class Search extends PureComponent<SearchProps, SearchState> {
         totalResults: 0,
         offset: 25,
         totalPages: 1,
-        currentPage: 0,
+        currentPage: 1,
         isLoading: true
     }
 
@@ -59,15 +59,14 @@ export default class Search extends PureComponent<SearchProps, SearchState> {
             results: search.results,
             totalResults: search.totalResults,
             totalPages: search.totalPages,
-            currentPage: search.page, // first page is always 0 in response
             isLoading: false
         })
         Logger.log(`Loaded ${this.state.results.length} assets`)
     }
 
-    private setPage = (page: number) => {
-        this.setState({ currentPage: page })
-        this.searchAssets()
+    private setPage = async (page: number) => {
+        await this.setState({ currentPage: page, isLoading: true })
+        await this.searchAssets()
     }
 
     public renderResults = () =>


### PR DESCRIPTION
Updates search query for new page counting in Brizo & Aquarius. All together will make the pagination show up if there're more than 1 `total_pages`.

- Requires Aquarius `v0.2.2.`
- closes https://github.com/oceanprotocol/aquarius/issues/169