### PR TITLE
Fix: file URLs get decrypted, not files

### DIFF
--- a/client/src/routes/Details/AssetFile.tsx
+++ b/client/src/routes/Details/AssetFile.tsx
@@ -25,7 +25,7 @@ export default class AssetFile extends PureComponent<
     public state = {
         isLoading: false,
         error: '',
-        message: 'Decrypting file, please sign...'
+        message: 'Decrypting file URL, please sign...'
     }
 
     private resetState = () => this.setState({ isLoading: true, error: '' })


### PR DESCRIPTION
This is a small thing, but it's important because we don't want to mislead people about how Ocean Protocol works.