### PR TITLE
Make page numbers part of URL

### DIFF
--- a/client/src/routes/Search.tsx
+++ b/client/src/routes/Search.tsx
@@ -34,8 +34,16 @@ export default class Search extends PureComponent<SearchProps, SearchState> {
 
     private readonly searchTerm = queryString.parse(this.props.location.search)
         .text
+    private readonly searchPage = queryString.parse(this.props.location.search)
+        .page
 
-    public componentDidMount() {
+    public async componentDidMount() {
+        // switch to respective page if query string is present
+        if (this.searchPage) {
+            const currentPage = Number(this.searchPage)
+            await this.setState({ currentPage })
+        }
+
         this.searchAssets()
     }
 

--- a/client/src/routes/Search.tsx
+++ b/client/src/routes/Search.tsx
@@ -10,7 +10,7 @@ import styles from './Search.module.scss'
 
 interface SearchProps {
     location: Location
-    history: History
+    history: any
 }
 
 interface SearchState {
@@ -73,6 +73,11 @@ export default class Search extends PureComponent<SearchProps, SearchState> {
     }
 
     private setPage = async (page: number) => {
+        this.props.history.push({
+            pathname: this.props.location.pathname,
+            search: `?text=${this.searchTerm}&page=${page}`
+        })
+
         await this.setState({ currentPage: page, isLoading: true })
         await this.searchAssets()
     }


### PR DESCRIPTION
- going to another page will update URL with `&page=PAGENUMBER`
- e.g. sharing a URL and accessing it directly with `page` parameter will switch view to respective page
- example: `/search?text=ocean&page=26`