### PR TITLE
Adapt to new faucet server response format

### DIFF
--- a/client/src/routes/Faucet.module.scss
+++ b/client/src/routes/Faucet.module.scss
@@ -12,6 +12,19 @@
 
 .success {
     color: $green;
+
+    p {
+        margin-top: $spacer / 2;
+    }
+
+    strong {
+        display: block;
+    }
+
+    code {
+        overflow-wrap: break-word;
+        display: inline;
+    }
 }
 
 .error {

--- a/client/src/routes/Faucet.tsx
+++ b/client/src/routes/Faucet.tsx
@@ -10,13 +10,15 @@ interface FaucetState {
     isLoading: boolean
     success?: string
     error?: string
+    trxHash?: string
 }
 
 export default class Faucet extends PureComponent<{}, FaucetState> {
     public state = {
         isLoading: false,
         success: undefined,
-        error: undefined
+        error: undefined,
+        trxHash: undefined
     }
 
     private getTokens = async (requestFromFaucet: () => any) => {
@@ -33,9 +35,12 @@ export default class Faucet extends PureComponent<{}, FaucetState> {
                 return
             }
 
+            const { trxHash } = response
+
             this.setState({
                 isLoading: false,
-                success: response.message
+                success: response.message,
+                trxHash
             })
         } catch (error) {
             this.setState({ isLoading: false, error })
@@ -51,7 +56,13 @@ export default class Faucet extends PureComponent<{}, FaucetState> {
     }
 
     private Success = () => (
-        <div className={styles.success}>{this.state.success}</div>
+        <div className={styles.success}>
+            <strong>{this.state.success}</strong>
+            <p>
+                <strong>Your Transaction Hash</strong>
+                <code>{this.state.trxHash}</code>
+            </p>
+        </div>
     )
 
     private Error = () => (

--- a/client/src/routes/Faucet.tsx
+++ b/client/src/routes/Faucet.tsx
@@ -25,18 +25,17 @@ export default class Faucet extends PureComponent<{}, FaucetState> {
         try {
             const response = await requestFromFaucet()
 
-            if (response.error) {
+            if (!response.success) {
                 this.setState({
                     isLoading: false,
-                    error: response.error
+                    error: response.message
                 })
-
                 return
             }
 
             this.setState({
                 isLoading: false,
-                success: 'Successfully added ETH to your account.'
+                success: response.message
             })
         } catch (error) {
             this.setState({ isLoading: false, error })

--- a/library.json
+++ b/library.json
@@ -20,6 +20,10 @@
     {
       "name": "squid-js",
       "version": "~0.5.3"
+    },
+    {
+      "name": "faucet",
+      "version": "~0.2.0"
     }
   ]
 }


### PR DESCRIPTION
Pass through success message, and show tx hash on success

Requires deployment of https://github.com/oceanprotocol/faucet/pull/23