### PR TITLE
fix datepicker styles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
+dist: xenial
 language: node_js
-node_js: node
+node_js:
+  - '11'
 
 script:
   # - ./scripts/install.sh # runs automatically with npm ci

--- a/client/src/components/atoms/Form/Input.tsx
+++ b/client/src/components/atoms/Form/Input.tsx
@@ -7,7 +7,6 @@ import Help from './Help'
 import Label from './Label'
 import Row from './Row'
 import InputGroup from './InputGroup'
-import 'react-datepicker/dist/react-datepicker-cssmodules.css'
 import styles from './Input.module.scss'
 
 interface InputProps {

--- a/client/src/components/atoms/Form/InputDate.module.scss
+++ b/client/src/components/atoms/Form/InputDate.module.scss
@@ -1,4 +1,5 @@
 @import '../../../styles/variables';
+@import '../../../../node_modules/react-datepicker/dist/react-datepicker-cssmodules.css';
 
 //
 // Date picker


### PR DESCRIPTION
Datepicker popup is broken on live right now:

<img width="735" alt="Screen Shot 2019-04-24 at 13 04 36" src="https://user-images.githubusercontent.com/90316/56654892-85a53a80-6691-11e9-86ba-9827e71d5702.png">

PR makes it look as it should be:

<img width="703" alt="Screen Shot 2019-04-24 at 13 04 53" src="https://user-images.githubusercontent.com/90316/56654909-93f35680-6691-11e9-8c00-840d6031ebf2.png">
