### PR TITLE
fix search titles

### DIFF
--- a/client/src/components/templates/Route.module.scss
+++ b/client/src/components/templates/Route.module.scss
@@ -18,12 +18,3 @@
     margin-top: $spacer / 2;
     font-size: $font-size-large;
 }
-
-.titleReverse {
-    composes: title;
-    color: $brand-grey-light;
-
-    span {
-        color: $brand-grey-dark;
-    }
-}

--- a/client/src/components/templates/Route.tsx
+++ b/client/src/components/templates/Route.tsx
@@ -7,14 +7,12 @@ import meta from '../../data/meta.json'
 const Route = ({
     title,
     description,
-    titleReverse,
     wide,
     children,
     className
 }: {
     title: string
     description?: string
-    titleReverse?: boolean
     children: any
     wide?: boolean
     className?: string
@@ -29,13 +27,7 @@ const Route = ({
         <Content wide={wide}>
             <article>
                 <header className={styles.header}>
-                    <h1
-                        className={
-                            titleReverse ? styles.titleReverse : styles.title
-                        }
-                    >
-                        {title}
-                    </h1>
+                    <h1 className={styles.title}>{title}</h1>
                     {description && (
                         <p
                             className={styles.description}

--- a/client/src/routes/Search.module.scss
+++ b/client/src/routes/Search.module.scss
@@ -1,5 +1,16 @@
 @import '../styles/variables';
 
+.resultsTitle {
+    color: $brand-grey-light;
+    font-size: $font-size-h3;
+    margin-top: -($spacer / 2);
+    margin-bottom: $spacer;
+
+    span {
+        color: $brand-grey-dark;
+    }
+}
+
 .results {
     display: grid;
     grid-template-columns: 1fr;

--- a/client/src/routes/Search.tsx
+++ b/client/src/routes/Search.tsx
@@ -102,13 +102,17 @@ export default class Search extends PureComponent<SearchProps, SearchState> {
         const { totalResults, totalPages, currentPage } = this.state
 
         return (
-            <Route
-                title={`${
-                    totalResults > 0 ? totalResults : ''
-                } Results for <span>${this.searchTerm}</span>`}
-                titleReverse
-                wide
-            >
+            <Route title="Search" wide>
+                {totalResults > 0 && (
+                    <h2
+                        className={styles.resultsTitle}
+                        dangerouslySetInnerHTML={{
+                            __html: `${totalResults} results for <span>${
+                                this.searchTerm
+                            }</span>`
+                        }}
+                    />
+                )}
                 {this.renderResults()}
 
                 <Pagination


### PR DESCRIPTION
Hotfix https://github.com/oceanprotocol/commons/commit/17082c817f11f5124eb5865371dd07e6806a77da introduced a bug for all search titles:

![Screenshot 2019-04-29 at 11 17 35](https://user-images.githubusercontent.com/90316/56889631-2ec7a880-6a77-11e9-8441-12bd7d914993.png)

So shuffle titles around so we don't have to use `dangerouslySetInnerHTML` in the route titles.

Resulting in:

<img width="1012" alt="Screen Shot 2019-04-29 at 12 02 33" src="https://user-images.githubusercontent.com/90316/56889508-cbd61180-6a76-11e9-8c32-119f83b3bd95.png">