### PR TITLE
fix react-ga initialization

### DIFF
--- a/client/src/hoc/withTracker.tsx
+++ b/client/src/hoc/withTracker.tsx
@@ -3,15 +3,15 @@ import ReactGA, { FieldsObject } from 'react-ga'
 import { RouteComponentProps } from 'react-router-dom'
 import { analyticsId } from '../config'
 
+ReactGA.initialize(analyticsId, {
+    testMode: process.env.NODE_ENV === 'test',
+    debug: false
+})
+
 const withTracker = <P extends RouteComponentProps>(
     WrappedComponent: any,
     options: FieldsObject = {}
 ) => {
-    ReactGA.initialize(analyticsId, {
-        testMode: process.env.NODE_ENV === 'test',
-        debug: false
-    })
-
     const trackPage = (page: string) => {
         options.isWeb3 = window.web3 !== undefined
 

--- a/client/src/routes/Details/AssetFile.test.tsx
+++ b/client/src/routes/Details/AssetFile.test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { render, fireEvent } from 'react-testing-library'
 import { DDO } from '@oceanprotocol/squid'
 import { StateMock } from '@react-mock/state'
+import ReactGA from 'react-ga'
 import { User } from '../../context'
 import AssetFile from './AssetFile'
 
@@ -30,6 +31,8 @@ const contextConnectedMock = {
     unlockAccounts: () => {},
     message: ''
 }
+
+ReactGA.initialize('foo', { testMode: true })
 
 describe('AssetFile', () => {
     it('renders without crashing', () => {


### PR DESCRIPTION
Solves 2 things:

- GA script was loaded multiple times, and added again on route updates
- tests were complaining about non-initialized react-ga