### PR TITLE
make price a string, Aquarius 0.2.7 validation updates

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2492,18 +2492,29 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
       },
       "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
         }
       }
     },
@@ -6693,6 +6704,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
       "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "dev": true,
       "requires": {
         "debug": "^3.2.6"
       },
@@ -6701,6 +6713,7 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -6708,7 +6721,8 @@
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1315,6 +1315,17 @@
       "resolved": "https://registry.npmjs.org/@oceanprotocol/typographies/-/typographies-0.1.0.tgz",
       "integrity": "sha512-kMsZsqvzpz9KzVbVZzllwhPoIC3zbqsdRrClagZL/C2PHzgLrKGC1kYn3gPt0RMIFg9ZjrwieKaxlgIK9i9zzg=="
     },
+    "@react-mock/fetch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@react-mock/fetch/-/fetch-0.3.0.tgz",
+      "integrity": "sha512-q1tqyrqeW4+J0R/rRghK86VG21fFFIMli1kxhi2z9wLAko10YNHB3UuI4fnXc+/kbjne0yVxyTp0s1xdzv+YzA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "fetch-mock": "^7.0.7",
+        "lodash": "^4.17.11"
+      }
+    },
     "@react-mock/state": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@react-mock/state/-/state-0.1.8.tgz",
@@ -2689,6 +2700,31 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
       "dev": true
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
     },
     "babel-preset-jest": {
       "version": "24.6.0",
@@ -6448,6 +6484,43 @@
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
         "pend": "~1.2.0"
+      }
+    },
+    "fetch-mock": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.3.3.tgz",
+      "integrity": "sha512-MHKcwZ4n9TmnfnVfelUBrrfxtC9tztafIR+F8l/Yu9N+y48fU1BAwj3iSxhYFYELVw73rCZh2DPWtWCekY/t+w==",
+      "dev": true,
+      "requires": {
+        "babel-polyfill": "^6.26.0",
+        "glob-to-regexp": "^0.4.0",
+        "path-to-regexp": "^2.2.1",
+        "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "glob-to-regexp": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+          "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+          "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "figgy-pudding": {

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,7 @@
     "@oceanprotocol/squid": "^0.5.14",
     "@oceanprotocol/typographies": "^0.1.0",
     "@sindresorhus/slugify": "^0.9.1",
-    "axios": "^0.18.0",
+    "axios": "^0.19.0",
     "classnames": "^2.2.6",
     "ethereum-blockies": "MyEtherWallet/blockies",
     "filesize": "^4.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -39,6 +39,7 @@
     "web3": "1.0.0-beta.37"
   },
   "devDependencies": {
+    "@react-mock/fetch": "^0.3.0",
     "@react-mock/state": "^0.1.8",
     "@testing-library/react": "^8.0.1",
     "@types/classnames": "^2.2.7",

--- a/client/src/models/AssetModel.ts
+++ b/client/src/models/AssetModel.ts
@@ -12,11 +12,11 @@ const AssetModel = {
         type: '',
         license: null,
         copyrightHolder: null,
-        workExample: null,
+        workExample: '',
         files: [],
         categories: [],
         links: [],
-        inLanguage: null,
+        inLanguage: '',
         tags: [],
         price: ''
     },

--- a/client/src/models/AssetModel.ts
+++ b/client/src/models/AssetModel.ts
@@ -18,7 +18,7 @@ const AssetModel = {
         links: [],
         inLanguage: null,
         tags: [],
-        price: null
+        price: ''
     },
     curation: {
         rating: null,

--- a/client/src/models/AssetModel.ts
+++ b/client/src/models/AssetModel.ts
@@ -19,15 +19,6 @@ const AssetModel = {
         inLanguage: '',
         tags: [],
         price: ''
-    },
-    curation: {
-        rating: null,
-        numVotes: null,
-        schema: null
-    },
-    additionalInformation: {
-        updateFrequency: null,
-        structuredMarkup: []
     }
 }
 

--- a/client/src/routes/Publish/Files/index.test.tsx
+++ b/client/src/routes/Publish/Files/index.test.tsx
@@ -6,7 +6,6 @@ const onChange = jest.fn()
 
 const files = [
     {
-        found: true,
         url: 'https://hello.com',
         checksum: 'cccccc',
         checksumType: 'MD5',
@@ -14,7 +13,8 @@ const files = [
         contentType: 'application/zip',
         resourceId: 'xxx',
         encoding: 'UTF-8',
-        compression: 'zip'
+        compression: 'zip',
+        found: true
     }
 ]
 

--- a/client/src/routes/Publish/Files/index.test.tsx
+++ b/client/src/routes/Publish/Files/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, fireEvent, waitForElement } from '@testing-library/react'
 import { FetchMock } from '@react-mock/fetch'
-import { serviceHost, servicePort, serviceScheme } from '../../../config'
+import { serviceUri } from '../../../config'
 import Files from '.'
 
 const onChange = jest.fn()
@@ -25,7 +25,7 @@ const renderComponent = () =>
         <FetchMock
             mocks={[
                 {
-                    matcher: `${serviceScheme}://${serviceHost}:${servicePort}/api/v1/urlcheck`,
+                    matcher: `${serviceUri}/api/v1/urlcheck`,
                     method: 'POST',
                     response: {
                         result: {

--- a/client/src/routes/Publish/Files/index.tsx
+++ b/client/src/routes/Publish/Files/index.tsx
@@ -115,6 +115,7 @@ export default class Files extends PureComponent<FilesProps, FilesStates> {
                     name={name}
                     value={JSON.stringify(files)}
                     onChange={onChange}
+                    data-testid="files"
                 />
 
                 <div className={styles.newItems}>

--- a/client/src/routes/Publish/Files/index.tsx
+++ b/client/src/routes/Publish/Files/index.tsx
@@ -8,17 +8,18 @@ import styles from './index.module.scss'
 
 import { serviceUri } from '../../../config'
 import cleanupContentType from '../../../utils/cleanupContentType'
+import { Logger } from '@oceanprotocol/squid'
 
-interface File {
+export interface File {
     url: string
-    found: boolean
+    contentType: string
     checksum?: string
     checksumType?: string
     contentLength?: number
-    contentType?: string
     resourceId?: string
     encoding?: string
     compression?: string
+    found: boolean // non-standard
 }
 
 interface FilesProps {
@@ -51,20 +52,10 @@ export default class Files extends PureComponent<FilesProps, FilesStates> {
     }
 
     private addItem = async (value: string) => {
-        let res: {
-            result: {
-                contentLength: number
-                contentType: string
-                found: boolean
-            }
-        }
-
         let file: File = {
             url: value,
-            found: false,
-            contentLength: 0,
             contentType: '',
-            compression: ''
+            found: false // non-standard
         }
 
         try {
@@ -75,13 +66,16 @@ export default class Files extends PureComponent<FilesProps, FilesStates> {
                     'Content-Type': 'application/json'
                 }
             })
-            res = await response.json()
-            file.contentLength = res.result.contentLength
-            file.contentType = res.result.contentType
-            file.compression = await cleanupContentType(res.result.contentType)
-            file.found = res.result.found
+
+            const json = await response.json()
+            const { contentLength, contentType, found } = json.result
+
+            file.contentLength = contentLength
+            file.contentType = contentType
+            file.compression = await cleanupContentType(contentType)
+            file.found = found
         } catch (error) {
-            // error
+            Logger.error(error.message)
         }
 
         this.props.files.push(file)

--- a/client/src/routes/Publish/Step.test.tsx
+++ b/client/src/routes/Publish/Step.test.tsx
@@ -12,7 +12,6 @@ const stateMock = {
 
 const propsMock = {
     inputChange: () => null,
-    inputToArrayChange: () => null,
     state: stateMock,
     title: 'Hello',
     description: 'description',

--- a/client/src/routes/Publish/Step.tsx
+++ b/client/src/routes/Publish/Step.tsx
@@ -28,9 +28,6 @@ interface StepProps {
             | ChangeEvent<HTMLSelectElement>
             | ChangeEvent<HTMLTextAreaElement>
     ): void
-    inputToArrayChange(
-        event: ChangeEvent<HTMLSelectElement> | ChangeEvent<HTMLInputElement>
-    ): void
     fields?: Fields
     state: any
     title: string

--- a/client/src/routes/Publish/index.test.tsx
+++ b/client/src/routes/Publish/index.test.tsx
@@ -1,11 +1,44 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import Publish from '.'
+import { User } from '../../context'
+import { userMockConnected } from '../../../__mocks__/user-mock'
 
-describe('Progress', () => {
+describe('Publish', () => {
     it('renders without crashing', () => {
-        const { container, getByText } = render(<Publish />)
+        const { container, getByText } = render(
+            <User.Provider value={userMockConnected}>
+                <Publish />
+            </User.Provider>
+        )
         expect(container.firstChild).toBeInTheDocument()
         expect(getByText('Next →')).toHaveAttribute('disabled')
+    })
+
+    it('next button works', () => {
+        const { getByText, getByLabelText, getByTestId } = render(
+            <User.Provider value={userMockConnected}>
+                <Publish />
+            </User.Provider>
+        )
+
+        // Title
+        const inputName = getByLabelText('Title')
+        fireEvent.change(inputName, {
+            target: { value: 'Hello' }
+        })
+
+        // Files
+        const inputFiles = getByTestId('files')
+        fireEvent.change(inputFiles, {
+            target: {
+                value: JSON.stringify([
+                    { url: 'https://demo.com', contentType: '', found: false }
+                ])
+            }
+        })
+
+        // expect(getByText('Next →')).not.toHaveAttribute('disabled')
+        fireEvent.click(getByText('Next →'))
     })
 })

--- a/client/src/routes/Publish/index.tsx
+++ b/client/src/routes/Publish/index.tsx
@@ -19,7 +19,7 @@ interface PublishState {
     dateCreated?: string
     description?: string
     files?: string[]
-    price?: number
+    price?: string
     author?: string
     type?: AssetType
     license?: string
@@ -44,7 +44,7 @@ export default class Publish extends Component<{}, PublishState> {
         dateCreated: new Date().toISOString(),
         description: '',
         files: [],
-        price: 0,
+        price: '0',
         author: '',
         type: 'dataset' as AssetType,
         license: '',
@@ -122,7 +122,7 @@ export default class Publish extends Component<{}, PublishState> {
             dateCreated: new Date().toISOString(),
             description: '',
             files: [],
-            price: 0,
+            price: '0',
             author: '',
             type: 'dataset' as AssetType,
             license: '',

--- a/client/src/routes/Publish/index.tsx
+++ b/client/src/routes/Publish/index.tsx
@@ -285,10 +285,6 @@ export default class Publish extends Component<{}, PublishState> {
                 type: this.state.type,
                 categories: [this.state.categories]
             })
-            // curation: Object.assign(AssetModel.curation),
-            // additionalInformation: Object.assign(
-            //     AssetModel.additionalInformation
-            // )
         }
 
         try {

--- a/client/src/routes/Publish/index.tsx
+++ b/client/src/routes/Publish/index.tsx
@@ -270,12 +270,12 @@ export default class Publish extends Component<{}, PublishState> {
         const { ocean } = this.context
         const account = await ocean.accounts.list()
 
-        // remove `found` attribute from all objects
-        // and use new array for hidden input
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        // const filesStandard = this.state.files.map(
-        //     ({ found, ...keepAttrs }) => keepAttrs // eslint-disable-line
-        // )
+        // remove `found` attribute from all File objects
+        // in a new array
+        const files = this.state.files.map(
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            ({ found, ...keepAttrs }: { found: boolean }) => keepAttrs
+        )
 
         const newAsset = {
             // OEP-08 Attributes
@@ -287,15 +287,15 @@ export default class Publish extends Component<{}, PublishState> {
                 author: this.state.author,
                 license: this.state.license,
                 copyrightHolder: this.state.copyrightHolder,
-                files: this.state.files,
+                files,
                 price: this.state.price,
                 type: this.state.type,
                 categories: [this.state.categories]
-            }),
-            curation: Object.assign(AssetModel.curation),
-            additionalInformation: Object.assign(
-                AssetModel.additionalInformation
-            )
+            })
+            // curation: Object.assign(AssetModel.curation),
+            // additionalInformation: Object.assign(
+            //     AssetModel.additionalInformation
+            // )
         }
 
         try {

--- a/client/src/routes/Publish/index.tsx
+++ b/client/src/routes/Publish/index.tsx
@@ -11,27 +11,28 @@ import ReactGA from 'react-ga'
 
 import { steps } from '../../data/form-publish.json'
 import Content from '../../components/atoms/Content'
+import { File } from './Files'
 
 type AssetType = 'dataset' | 'algorithm' | 'container' | 'workflow' | 'other'
 
 interface PublishState {
     name?: string
     dateCreated?: string
-    description?: string
-    files?: string[]
     price?: string
     author?: string
-    type?: AssetType
     license?: string
+    description?: string
+    files?: File[]
+    type?: AssetType
     copyrightHolder?: string
-    categories?: string
-    tags?: string[]
+    categories?: string[]
+
+    currentStep?: number
+    publishingStep?: number
     isPublishing?: boolean
     isPublished?: boolean
     publishedDid?: string
     publishingError?: string
-    publishingStep?: number
-    currentStep?: number
     validationStatus?: any
 }
 
@@ -39,7 +40,6 @@ export default class Publish extends Component<{}, PublishState> {
     public static contextType = User
 
     public state = {
-        currentStep: 1,
         name: '',
         dateCreated: new Date().toISOString(),
         description: '',
@@ -49,7 +49,9 @@ export default class Publish extends Component<{}, PublishState> {
         type: 'dataset' as AssetType,
         license: '',
         copyrightHolder: '',
-        categories: '',
+        categories: [],
+
+        currentStep: 1,
         isPublishing: false,
         isPublished: false,
         publishedDid: '',
@@ -127,7 +129,7 @@ export default class Publish extends Component<{}, PublishState> {
             type: 'dataset' as AssetType,
             license: '',
             copyrightHolder: '',
-            categories: '',
+            categories: [],
             isPublishing: false,
             isPublished: false,
             publishingStep: 0,
@@ -267,6 +269,14 @@ export default class Publish extends Component<{}, PublishState> {
 
         const { ocean } = this.context
         const account = await ocean.accounts.list()
+
+        // remove `found` attribute from all objects
+        // and use new array for hidden input
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        // const filesStandard = this.state.files.map(
+        //     ({ found, ...keepAttrs }) => keepAttrs // eslint-disable-line
+        // )
+
         const newAsset = {
             // OEP-08 Attributes
             // https://github.com/oceanprotocol/OEPs/tree/master/8
@@ -280,10 +290,7 @@ export default class Publish extends Component<{}, PublishState> {
                 files: this.state.files,
                 price: this.state.price,
                 type: this.state.type,
-                categories: [this.state.categories],
-                workExample: undefined,
-                inLanguage: undefined,
-                tags: ''
+                categories: [this.state.categories]
             }),
             curation: Object.assign(AssetModel.curation),
             additionalInformation: Object.assign(

--- a/client/src/routes/Publish/index.tsx
+++ b/client/src/routes/Publish/index.tsx
@@ -273,7 +273,10 @@ export default class Publish extends Component<{}, PublishState> {
             base: Object.assign(AssetModel.base, {
                 name: this.state.name,
                 description: this.state.description,
-                dateCreated: new Date(this.state.dateCreated).toISOString(),
+                dateCreated:
+                    new Date(this.state.dateCreated)
+                        .toISOString()
+                        .split('.')[0] + 'Z', // remove milliseconds
                 author: this.state.author,
                 license: this.state.license,
                 copyrightHolder: this.state.copyrightHolder,

--- a/client/src/routes/Publish/index.tsx
+++ b/client/src/routes/Publish/index.tsx
@@ -83,16 +83,6 @@ export default class Publish extends Component<{}, PublishState> {
         })
     }
 
-    private inputToArrayChange = (
-        event: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLSelectElement>
-    ) => {
-        this.validateInputs(event.currentTarget.name, event.currentTarget.value)
-
-        this.setState({
-            [event.currentTarget.name]: [event.currentTarget.value]
-        })
-    }
-
     private next = () => {
         let { currentStep } = this.state
         const totalSteps = steps.length
@@ -353,7 +343,6 @@ export default class Publish extends Component<{}, PublishState> {
                                 currentStep={this.state.currentStep}
                                 fields={step.fields}
                                 inputChange={this.inputChange}
-                                inputToArrayChange={this.inputToArrayChange}
                                 state={this.state}
                                 next={this.next}
                                 prev={this.prev}

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "aquarius",
-      "version": "~0.2.6"
+      "version": "~0.2.8"
     },
     {
       "name": "squid-js",

--- a/library.json
+++ b/library.json
@@ -11,11 +11,11 @@
     },
     {
       "name": "brizo",
-      "version": "~0.3.9"
+      "version": "~0.3.10"
     },
     {
       "name": "aquarius",
-      "version": "~0.2.8"
+      "version": "~0.2.9"
     },
     {
       "name": "squid-js",

--- a/server/src/routes/UrlCheckRouter.ts
+++ b/server/src/routes/UrlCheckRouter.ts
@@ -31,8 +31,9 @@ export class UrlCheckRouter {
                     result.found = true
 
                     if (response.headers['content-length']) {
-                        result.contentLength =
+                        result.contentLength = parseInt(
                             response.headers['content-length']
+                        ) // convert to number
                     }
 
                     if (response.headers['content-type']) {


### PR DESCRIPTION
Following changes in OEP-8 https://github.com/oceanprotocol/OEPs/pull/167 & https://github.com/oceanprotocol/OEPs/pull/169

Requires Aquarius `v0.2.7`, tested against `v0.2.8`
Closes #149