### PR TITLE
Add range error handling

### DIFF
--- a/server/src/routes/UrlCheckRouter.ts
+++ b/server/src/routes/UrlCheckRouter.ts
@@ -24,7 +24,8 @@ export class UrlCheckRouter {
             (error, response) => {
                 if (
                     response &&
-                    response.statusCode.toString().startsWith('2')
+                    (response.statusCode.toString().startsWith('2') ||
+                    response.statusCode.toString().startsWith('416'))
                 ) {
                     const result: any = {}
                     result.found = true


### PR DESCRIPTION
Server may return 416 HTTP error to HEAD request if it does not support range requests, content length is still there so we're ok with this.