### PR TITLE
output version numbers, simplify release tasks, make automatic changelog work

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Builds the client for production to the `./client/build` folder, and the server 
 
 From a clean `master` branch you can run any release task doing the following:
 
-- bumps the project version
+- bumps the project version in `package.json`, `client/package.json`, `server/package.json`
 - auto-generates and updates the CHANGELOG.md file from commit messages
 - creates a Git tag
 - commits and pushes everything

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you're a developer and want to contribute to, or want to utilize this marketp
 - [✨ Code Style](#-code-style)
 - [🛳 Production](#-production)
 - [⬆️ Releases](#️-releases)
-- [Changelog](#changelog)
+- [📜 Changelog](#-changelog)
 - [🎁 Contributing](#-contributing)
 - [🏛 License](#-license)
 
@@ -125,6 +125,7 @@ Builds the client for production to the `./client/build` folder, and the server 
 From a clean `master` branch you can run any release task doing the following:
 
 - bumps the project version
+- auto-generates and updates the CHANGELOG.md file from commit messages
 - creates a Git tag
 - commits and pushes everything
 - creates a GitHub release with commit messages as description
@@ -132,30 +133,16 @@ From a clean `master` branch you can run any release task doing the following:
 You can execute the script using {major|minor|patch} as first argument to bump the version accordingly:
 
 - To bump a patch version: `npm run release`
-- To bump a minor version: `npm run release-minor`
-- To bump a major version: `npm run release-major`
+- To bump a minor version: `npm run release minor`
+- To bump a major version: `npm run release major`
 
-By creating the Git tag with these tasks, Travis will trigger a new Kubernetes deployment automatically aftr a successful tag build.
+By creating the Git tag with these tasks, Travis will trigger a new Kubernetes live deployment automatically, after a successful tag build.
 
 For the GitHub releases steps a GitHub personal access token, exported as `GITHUB_TOKEN` is required. [Setup](https://github.com/release-it/release-it#github-releases)
 
-## Changelog
+## 📜 Changelog
 
-See the [CHANGELOG.md](./CHANGELOG.md) file.
-
-This file is auto-generated from commit & PR messages upon running:
-
-```bash
-npm run changelog
-```
-
-This will update the CHANGELOG.md file with commit messages in a nice format. Doing a release will not automatically update that changelog file. So after every release this needs to done with the above command and simply committed back into `master`.
-
-For convenience, you can use this command which updates the CHANGELOG.md file, commits the result, and pushes changes to `master`:
-
-```bash
-npm run changelog:commit
-```
+See the [CHANGELOG.md](./CHANGELOG.md) file. This file is auto-generated during the above mentioned release process.
 
 ## 🎁 Contributing
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "commons-client",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "commons-client",
   "description": "Ocean Protocol marketplace frontend to explore, download, and publish open data sets.",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/components/atoms/VersionNumbers.module.scss
+++ b/client/src/components/atoms/VersionNumbers.module.scss
@@ -1,0 +1,21 @@
+@import '../../styles/variables';
+
+.version {
+    font-family: $font-family-monospace;
+    font-size: $font-size-mini;
+    margin-top: $spacer;
+}
+
+.more {
+    cursor: help;
+    display: inline-block;
+    margin-left: $spacer / 4;
+    margin-bottom: -.1rem;
+    vertical-align: middle;
+
+    svg {
+        width: $font-size-mini;
+        height: $font-size-mini;
+        fill: currentColor;
+    }
+}

--- a/client/src/components/atoms/VersionNumbers.tsx
+++ b/client/src/components/atoms/VersionNumbers.tsx
@@ -1,0 +1,73 @@
+import React, { PureComponent } from 'react'
+import { version } from '../../../package.json'
+import { version as versionSquid } from '@oceanprotocol/squid/package.json'
+import styles from './VersionNumbers.module.scss'
+
+import {
+    aquariusHost,
+    aquariusPort,
+    aquariusScheme,
+    brizoHost,
+    brizoPort,
+    brizoScheme
+} from '../../config'
+import { Logger } from '@oceanprotocol/squid'
+
+const commonsVersion =
+    process.env.NODE_ENV === 'production' ? `v${version}` : `v${version}-dev`
+
+export default class VersionNumbers extends PureComponent {
+    public state = {
+        commons: commonsVersion,
+        squidJs: `v${versionSquid}`,
+        aquarius: 'v0.0.0',
+        brizo: 'v0.0.0'
+    }
+
+    public async componentDidMount() {
+        try {
+            const {
+                versionAquarius,
+                versionBrizo
+            } = await this.getComponentVersions()
+
+            this.setState({
+                aquarius: `v${versionAquarius}`,
+                brizo: `v${versionBrizo}`
+            })
+        } catch (error) {
+            Logger.error(error.message)
+        }
+    }
+
+    private async getComponentVersions() {
+        const responseAquarius = await fetch(
+            `${aquariusScheme}://${aquariusHost}:${aquariusPort}`
+        )
+        const jsonAquarius = await responseAquarius.json()
+        const versionAquarius = jsonAquarius.version
+
+        const responseBrizo = await fetch(
+            `${brizoScheme}://${brizoHost}:${brizoPort}`
+        )
+        const jsonBrizo = await responseBrizo.json()
+        const versionBrizo = jsonBrizo.version
+
+        return { versionAquarius, versionBrizo }
+    }
+
+    public render() {
+        const { commons, squidJs, brizo, aquarius } = this.state
+
+        return (
+            <p className={styles.version}>
+                <a
+                    title={`Squid-js ${squidJs} - Brizo ${brizo} - Aquarius ${aquarius}`}
+                    href={`https://github.com/oceanprotocol/commons/releases/tag/${commons}`}
+                >
+                    {commons}
+                </a>
+            </p>
+        )
+    }
+}

--- a/client/src/components/organisms/Footer.module.scss
+++ b/client/src/components/organisms/Footer.module.scss
@@ -91,3 +91,9 @@
         }
     }
 }
+
+.version {
+    font-family: $font-family-monospace;
+    font-size: $font-size-mini;
+    margin-top: $spacer;
+}

--- a/client/src/components/organisms/Footer.module.scss
+++ b/client/src/components/organisms/Footer.module.scss
@@ -91,9 +91,3 @@
         }
     }
 }
-
-.version {
-    font-family: $font-family-monospace;
-    font-size: $font-size-mini;
-    margin-top: $spacer;
-}

--- a/client/src/components/organisms/Footer.tsx
+++ b/client/src/components/organisms/Footer.tsx
@@ -5,33 +5,7 @@ import { ReactComponent as AiCommons } from '../../img/aicommons.svg'
 import styles from './Footer.module.scss'
 
 import meta from '../../data/meta.json'
-import { version } from '../../../package.json'
-import { version as versionSquid } from '@oceanprotocol/squid/package.json'
-
-const VersionNumber = () => {
-    const versionOutput =
-        process.env.NODE_ENV === 'production'
-            ? `v${version}`
-            : `v${version}-dev`
-
-    return (
-        <p className={styles.version}>
-            <a
-                title="See commons release on GitHub"
-                href={`https://github.com/oceanprotocol/commons/releases/tag/v${version}`}
-            >
-                {versionOutput}
-            </a>{' '}
-            &mdash;{' '}
-            <a
-                title="See squid-js release on GitHub"
-                href={`https://github.com/oceanprotocol/squid-js/releases/tag/v${versionSquid}`}
-            >
-                squid-js v{versionSquid}
-            </a>
-        </p>
-    )
-}
+import VersionNumbers from '../atoms/VersionNumbers'
 
 const Footer = () => (
     <footer className={styles.footer}>
@@ -57,7 +31,7 @@ const Footer = () => (
                         <AiCommons />
                     </a>
                 </p>
-                <VersionNumber />
+                <VersionNumbers />
             </Content>
         </aside>
 

--- a/client/src/components/organisms/Footer.tsx
+++ b/client/src/components/organisms/Footer.tsx
@@ -5,6 +5,33 @@ import { ReactComponent as AiCommons } from '../../img/aicommons.svg'
 import styles from './Footer.module.scss'
 
 import meta from '../../data/meta.json'
+import { version } from '../../../package.json'
+import { version as versionSquid } from '@oceanprotocol/squid/package.json'
+
+const VersionNumber = () => {
+    const versionOutput =
+        process.env.NODE_ENV === 'production'
+            ? `v${version}`
+            : `v${version}-dev`
+
+    return (
+        <p className={styles.version}>
+            <a
+                title="See commons release on GitHub"
+                href={`https://github.com/oceanprotocol/commons/releases/tag/v${version}`}
+            >
+                {versionOutput}
+            </a>{' '}
+            &mdash;{' '}
+            <a
+                title="See squid-js release on GitHub"
+                href={`https://github.com/oceanprotocol/squid-js/releases/tag/v${versionSquid}`}
+            >
+                squid-js v{versionSquid}
+            </a>
+        </p>
+    )
+}
 
 const Footer = () => (
     <footer className={styles.footer}>
@@ -30,6 +57,7 @@ const Footer = () => (
                         <AiCommons />
                     </a>
                 </p>
+                <VersionNumber />
             </Content>
         </aside>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -249,6 +249,19 @@
         "url-template": "^2.0.8"
       }
     },
+    "@release-it/bumper": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@release-it/bumper/-/bumper-1.0.2.tgz",
+      "integrity": "sha512-bcBiXVmnBMhb6LjyRPqyyWGCT89RQpszqMm376k/hbLAClWaX+LXX+05IFmScbWZe51K/tr6Gwq5UEwhio8+oQ==",
+      "dev": true,
+      "requires": {
+        "detect-indent": "^6.0.0",
+        "lodash.castarray": "^4.4.0",
+        "lodash.get": "^4.4.2",
+        "mock-fs": "^4.9.0",
+        "release-it": "^11.0.1"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -1345,6 +1358,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-1.0.1.tgz",
       "integrity": "sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
+      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
       "dev": true
     },
     "detect-repo-changelog": {
@@ -3494,6 +3513,12 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
+    "lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU=",
+      "dev": true
+    },
     "lodash.find": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
@@ -3899,6 +3924,12 @@
           "dev": true
         }
       }
+    },
+    "mock-fs": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.0.tgz",
+      "integrity": "sha512-eBpLEjI6tK4RKK44BbUBQu89lrNh+5WeX3wf2U6Uwo6RtRGAQ77qvKeuuQh3lVXHF1aPndVww9VcjqmLThIdtA==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@release-it/bumper": "^1.0.2",
     "@typescript-eslint/eslint-plugin": "^1.7.0",
     "@typescript-eslint/parser": "^1.7.0",
     "auto-changelog": "^1.13.0",
@@ -47,6 +48,15 @@
       "beforeStart": "npm test",
       "beforeStage": "npm run changelog",
       "afterRelease": "echo Successfully released ${name} v${version} to ${repo.repository}."
+    },
+    "plugins": {
+      "@release-it/bumper": {
+        "out": [
+          "package.json",
+          "client/package.json",
+          "server/package.json"
+        ]
+      }
     },
     "git": {
       "tagName": "v${version}"

--- a/package.json
+++ b/package.json
@@ -16,12 +16,8 @@
     "lint:js": "eslint --ignore-path .gitignore --ignore-path .prettierignore --ext .ts,.tsx .",
     "lint:fix": "eslint --fix --ignore-path .gitignore --ignore-path .prettierignore --ext .ts,.tsx .",
     "lint": "npm run lint:js && npm run lint:css",
-    "release": "./node_modules/release-it/bin/release-it.js --git.tagName='v${version}' --github.release --non-interactive --no-npm.publish",
-    "release-minor": "./node_modules/release-it/bin/release-it.js minor --git.tagName='v${version}' --github.release --non-interactive --no-npm.publish",
-    "release-major": "./node_modules/release-it/bin/release-it.js major --git.tagName='v${version}' --github.release --non-interactive --no-npm.publish",
-    "changelog": "auto-changelog",
-    "changelog:commit": "npm run changelog && git add CHANGELOG.md && git commit -m 'update changelog' && git push",
-    "beforeStage": "npm run changelog"
+    "release": "release-it --non-interactive",
+    "changelog": "auto-changelog -p"
   },
   "dependencies": {},
   "devDependencies": {
@@ -45,5 +41,21 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/oceanprotocol/commons"
+  },
+  "release-it": {
+    "scripts": {
+      "beforeStart": "npm test",
+      "beforeStage": "npm run changelog",
+      "afterRelease": "echo Successfully released ${name} v${version} to ${repo.repository}."
+    },
+    "git": {
+      "tagName": "v${version}"
+    },
+    "github": {
+      "release": true
+    },
+    "npm": {
+      "publish": false
+    }
   }
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "commons-server",
-  "version": "1.0.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "commons-server",
   "description": "Ocean Protocol marketplace backend.",
-  "version": "1.0.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "main": "dist/server.js",
   "scripts": {


### PR DESCRIPTION
Release scripts were a bit repetitive and changelog script was misconfigured. Bumping version is now also done in `client/package.json` & `server/package.json`, making out put of version number possible.

Patch release task is the same, but minor and major bumps slightly changed:

- `npm run release-minor` -> `npm run release minor`
- `npm run release-major` -> `npm run release major`

Updating all `package.json` version numbers makes outputting version number of commons in footer possible, linked to latest release on GitHub:

<img width="541" alt="Screen Shot 2019-05-28 at 13 33 01" src="https://user-images.githubusercontent.com/90316/58475054-2f725e00-814d-11e9-9e17-ec108e5f8732.png">

Also fetches the version numbers from squid-js, Brizo & Aquarius which are shown when hovering over the version number:

<img width="592" alt="Screen Shot 2019-05-28 at 13 33 07" src="https://user-images.githubusercontent.com/90316/58475069-3ac58980-814d-11e9-989e-e617b204ccd6.png">


The `-dev` is only appended in non-production builds.

Closes #140