### PR TITLE
fix account address display in Firefox

### DIFF
--- a/client/src/components/atoms/Account.tsx
+++ b/client/src/components/atoms/Account.tsx
@@ -9,7 +9,7 @@ const Account = ({ account }: { account: string }) => {
     return account && blockies ? (
         <div className={styles.account}>
             <img className={styles.blockies} src={blockies} alt="Blockies" />
-            <Dotdotdot clamp={1}>{account}</Dotdotdot>
+            <Dotdotdot clamp={2}>{account}</Dotdotdot>
         </div>
     ) : (
         <em>No account selected</em>


### PR DESCRIPTION
Is hidden in Firefox. Seems to be an issue with `React-dotdotdot`: https://github.com/CezaryDanielNowak/React-dotdotdot/issues/10

Setting `clamp` to `2` seem to still render just 1 line maximum in all browsers, and makes it visible in Firefox again.