### PR TITLE
switch to new Travis caching strategy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,7 @@ script:
 notifications:
   email: false
 
-cache:
-  directories:
-    - node_modules
+cache: npm
 
 deploy:
   - provider: script


### PR DESCRIPTION
Builds were sometimes stalling on removing `node_modules`. When using a `package-lock` with `npm ci`, Travis caching should always use the new preferred method https://docs.travis-ci.com/user/caching/#npm-cache instead of caching `node_modules` directly