### PR TITLE
hotfix for failing server run on Docker

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -13,5 +13,5 @@
     },
     "types": ["node", "jest"]
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
This line made a `src/` & `test/` folder within the `dist/` folder. https://github.com/oceanprotocol/commons/compare/v0.4.1...v0.4.2#diff-0b0ced16261bfb7084130d94ec04d96fR16