### PR TITLE
bump to squid-js v0.6.0

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1291,16 +1291,16 @@
       "integrity": "sha512-p2n505t2K0zD1ZvGPhI6EsSviEVLCB7BYowhf/ONmVaWED138PaG4Z9nY6YuHU383uOoIWT+Lq3dLkFzDzstXw=="
     },
     "@oceanprotocol/keeper-contracts": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/keeper-contracts/-/keeper-contracts-0.9.7.tgz",
-      "integrity": "sha512-nOpbSE/BG+tQBfLXZ/EqSOvUPzOuot84vHxjAfEU8K3v4eOnqFJVo+oyB7KlcF87wBJXDmi/Ir9qHY4c0Saipg=="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/keeper-contracts/-/keeper-contracts-0.10.3.tgz",
+      "integrity": "sha512-Nvnk9nNWMmfXz38bHRHHNgc8MGmFPZTkXPBWbEXR9+maJq5/kRFx8OckroKqmYXX4QBEh5frwd77omNOL2MUNw=="
     },
     "@oceanprotocol/squid": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/squid/-/squid-0.5.17.tgz",
-      "integrity": "sha512-yoZCKQ/QoOxgnhTHZFdeMknTRCktPZxSe/2ooDkf7ICaqwbVXMYspkMO+SDLQ+PAYncP4IZYVjr513ZkbQBYZw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/squid/-/squid-0.6.0.tgz",
+      "integrity": "sha512-agTeWx4ownJzGelKLW8qPIrXyoG8JZNR5vGkMppGGLL+vIGYWp9c6FbzznA8A1j2t8g99juGWoxM7v+Jyeq5Ww==",
       "requires": {
-        "@oceanprotocol/keeper-contracts": "^0.9.7",
+        "@oceanprotocol/keeper-contracts": "^0.10.3",
         "bignumber.js": "^8.1.1",
         "deprecated-decorator": "^0.1.6",
         "node-fetch": "^2.6.0",

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@oceanprotocol/art": "^2.2.0",
-    "@oceanprotocol/squid": "^0.5.17",
+    "@oceanprotocol/squid": "^0.6.0",
     "@oceanprotocol/typographies": "^0.1.0",
     "@sindresorhus/slugify": "^0.9.1",
     "axios": "^0.19.0",


### PR DESCRIPTION
New squid-js `v0.6.0` with keeper-contracts `v0.10.3`