### PR TITLE
Disable auto-deployments for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,11 +61,10 @@ cache:
   directories:
     # cache folder with Cypress binary
     - ~/.cache
-
-deploy:
-  - provider: script
-    skip_cleanup: true
-    script: bash -ex ./scripts/deploy_on_k8s.sh
-    on:
-      tags: true
-      all_branches: true
+# deploy:
+#   - provider: script
+#     skip_cleanup: true
+#     script: bash -ex ./scripts/deploy_on_k8s.sh
+#     on:
+#       tags: true
+#       all_branches: true


### PR DESCRIPTION
Because of Brizo and DDO changes coming up, it's best to manually deploy in the different networks for the time being.

Closes https://github.com/oceanprotocol/atlantic/issues/86