### PR TITLE
get faucet network from response

### DIFF
--- a/client/src/components/molecules/VersionNumbers/index.test.tsx
+++ b/client/src/components/molecules/VersionNumbers/index.test.tsx
@@ -34,7 +34,8 @@ const stateMockIncomplete = {
     },
     faucet: {
         name: 'Faucet',
-        version: undefined
+        version: undefined,
+        network: undefined
     },
     status: {
         ok: false,
@@ -46,7 +47,8 @@ const stateMockIncomplete = {
 const mockResponse = {
     data: {
         software: 'Faucet',
-        version: '6.6.6'
+        version: '6.6.6',
+        network: 'Pacific'
     }
 }
 

--- a/client/src/components/molecules/VersionNumbers/index.tsx
+++ b/client/src/components/molecules/VersionNumbers/index.tsx
@@ -47,14 +47,6 @@ export default class VersionNumbers extends PureComponent<
         ? 'Spree'
         : new URL(nodeUri).hostname.split('.')[0]
 
-    public faucetNetwork = faucetUri.includes('dev-ocean')
-        ? new URL(faucetUri).hostname.split('.')[1]
-        : faucetUri.includes('oceanprotocol.com')
-        ? 'Pacific'
-        : faucetUri.includes('localhost')
-        ? 'Spree'
-        : 'Unknown'
-
     // define a minimal default state to fill UI
     public state: VersionNumbersState = {
         commons: {
@@ -77,7 +69,7 @@ export default class VersionNumbers extends PureComponent<
         faucet: {
             name: 'Faucet',
             version: '',
-            network: this.faucetNetwork,
+            network: '',
             status: OceanPlatformTechStatus.Loading
         },
         status: {
@@ -135,11 +127,14 @@ export default class VersionNumbers extends PureComponent<
             // fail silently
             if (response.status !== 200) return
 
+            const { version, network } = response.data
+
             this.setState({
                 ...this.state,
                 faucet: {
                     ...this.state.faucet,
-                    version: response.data.version,
+                    version,
+                    network,
                     status: OceanPlatformTechStatus.Working
                 }
             })

--- a/library.json
+++ b/library.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "faucet",
-      "version": "~0.2.4"
+      "version": "~0.3.1"
     }
   ]
 }


### PR DESCRIPTION
Looks like before but remove network detection based on deployed url and use the network detection from faucet `v0.3.1`