### PR TITLE
switch Barge to --no-commons flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 sudo: required
 language: node_js
 node_js:
-  - "11"
+  - '11'
 
 services:
   - docker
@@ -47,7 +47,7 @@ before_script:
   - ./cc-test-reporter before-build
   - git clone https://github.com/oceanprotocol/barge
   - cd barge
-  - bash -x start_ocean.sh --no-pleuston 2>&1 > start_ocean.log &
+  - bash -x start_ocean.sh --no-commons 2>&1 > start_ocean.log &
   - cd ..
 
 script:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ git clone git@github.com:oceanprotocol/barge.git
 cd barge
 
 # startup with local Spree node
-./start_ocean.sh --latest --no-pleuston
+./start_ocean.sh --no-commons
 ```
 
 Then set [environment variables](#️-environment-variables) to use those local connections.


### PR DESCRIPTION
Because `--no-pleuston` has been deprecated in https://github.com/oceanprotocol/barge/pull/189