### PR TITLE
bump to squid.js v2 beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ env:
     - IPFS_GATEWAY_URI="https://ipfs.oceanprotocol.com"
 
     # start Barge with these versions
-    - BRIZO_VERSION=v0.8.1
-    - AQUARIUS_VERSION=v1.0.5
+    - BRIZO_VERSION=v0.9.3
+    - AQUARIUS_VERSION=v1.0.7
     - KEEPER_VERSION=v0.13.2
-    - EVENTS_HANDLER_VERSION=v0.4.4
+    - EVENTS_HANDLER_VERSION=v0.4.5
     - KEEPER_OWNER_ROLE_ADDRESS="0xe2DD09d719Da89e5a3D0F2549c7E24566e947260"
     - FAUCET_TIMESPAN=0
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1845,9 +1845,9 @@
       }
     },
     "@oceanprotocol/squid": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@oceanprotocol/squid/-/squid-1.3.0.tgz",
-      "integrity": "sha512-1/k1W5yMGIlsmN7O3mTkQ5VMB7qD4w9VnkoiTd/cIuGks73KsHRuHH5dEn99PUigacc6WwX5BBl8Osr3Nv5T8g==",
+      "version": "2.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@oceanprotocol/squid/-/squid-2.0.0-beta.3.tgz",
+      "integrity": "sha512-ms/keYZs6GaZQlsiFkAlNHnA0OC6ksap8yKeTXQfc7/6MXLpRibrG3KKOkxKYzOYUnoEbbNHA5LZ43SAYkyAUA==",
       "requires": {
         "@ethereum-navigator/navigator": "^0.4.1",
         "@oceanprotocol/keeper-contracts": "^0.13.2",
@@ -20910,9 +20910,9 @@
       }
     },
     "tr46": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.0.tgz",
-      "integrity": "sha512-LrErSqfhdUw73AC/eXV2fEmNkvgSYxfm5lvxnLvuVgoVDknvD28Pa5FeDGc8RuVouDxUD3GnHHFv7xnBp7As5w==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+      "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
       "requires": {
         "punycode": "^2.1.1"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@oceanprotocol/art": "^2.2.0",
-    "@oceanprotocol/squid": "^1.3.0",
+    "@oceanprotocol/squid": "next",
     "@oceanprotocol/typographies": "^0.1.0",
     "@sindresorhus/slugify": "^0.10.0",
     "@truffle/hdwallet-provider": "^1.0.30",

--- a/client/src/components/templates/Asset/AssetFile.tsx
+++ b/client/src/components/templates/Asset/AssetFile.tsx
@@ -59,8 +59,6 @@ export default class AssetFile extends PureComponent<
 
         try {
             const accounts = await ocean.accounts.list()
-            const service = ddo.findServiceByType('access')
-
             const agreements = await ocean.keeper.conditions.accessSecretStoreCondition.getGrantedDidByConsumer(
                 accounts[0].id
             )
@@ -74,7 +72,7 @@ export default class AssetFile extends PureComponent<
                 ;({ agreementId } = agreement)
             } else {
                 agreementId = await ocean.assets
-                    .order(ddo.id, service.index, accounts[0])
+                    .order(ddo.id, accounts[0])
                     .next((step: number) => this.setState({ step }))
             }
 
@@ -84,7 +82,6 @@ export default class AssetFile extends PureComponent<
             const path = await ocean.assets.consume(
                 agreementId,
                 ddo.id,
-                service.index,
                 accounts[0],
                 '',
                 index


### PR DESCRIPTION
Switch to `next` of squid.js, currently released from https://github.com/oceanprotocol/squid-js/pull/350