### PR TITLE
remove npm run build

### DIFF
--- a/client/scripts/docker-entrypoint.sh
+++ b/client/scripts/docker-entrypoint.sh
@@ -6,6 +6,5 @@ if [ "${LOCAL_CONTRACTS}" = "true" ]; then
     sleep 2
   done
 fi
-npm run build
 echo "Starting Commons..."
 serve -l tcp://"${LISTEN_ADDRESS}":"${LISTEN_PORT}" -s /app/frontend/build/

--- a/client/scripts/docker-entrypoint.sh
+++ b/client/scripts/docker-entrypoint.sh
@@ -5,6 +5,7 @@ if [ "${LOCAL_CONTRACTS}" = "true" ]; then
   while [ ! -f "/app/frontend/node_modules/@oceanprotocol/keeper-contracts/artifacts/ready" ]; do
     sleep 2
   done
+  npm run build
 fi
 echo "Starting Commons..."
 serve -l tcp://"${LISTEN_ADDRESS}":"${LISTEN_PORT}" -s /app/frontend/build/


### PR DESCRIPTION
No need to run npm run build in docker entrypoint, because the build is done when docker is created.

Runnning build on every startup will require a lot of resources that are not used anymore.
Commons client can be run easily with half CPU & 300MB RAM, but for build it requires at least 2 CPU & 1GB RAM.